### PR TITLE
Implement plugin server architecture

### DIFF
--- a/src/mcp_platform/main.py
+++ b/src/mcp_platform/main.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from fastapi import FastAPI
+
+from .servers.base import ToolServerBase
+
+
+def create_app() -> FastAPI:
+    """Create FastAPI app with dynamically discovered tool servers."""
+    app = FastAPI()
+    package = importlib.import_module("mcp_platform.servers")
+    for mod_info in pkgutil.iter_modules(package.__path__):
+        if mod_info.name == "base":
+            continue
+        module = importlib.import_module(f"mcp_platform.servers.{mod_info.name}")
+        for attr in dir(module):
+            obj = getattr(module, attr)
+            if (
+                isinstance(obj, type)
+                and issubclass(obj, ToolServerBase)
+                and obj is not ToolServerBase
+            ):
+                server = obj()
+                mount_path = "/" + mod_info.name.replace("_tool", "")
+                app.include_router(server.router(), prefix=mount_path)
+
+    return app

--- a/src/mcp_platform/servers/base.py
+++ b/src/mcp_platform/servers/base.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+from mcp.server import FastMCP
+
+
+class ToolCall(BaseModel):
+    """Schema for tool invocation payload."""
+
+    name: str
+    arguments: dict[str, Any] | None = None
+
+
+class ToolServerBase(ABC):
+    """Abstract base class for pluggable tool servers."""
+
+    @property
+    @abstractmethod
+    def app(self) -> FastMCP:
+        """Return the FastMCP instance exposed by this server."""
+        raise NotImplementedError
+
+    def router(self) -> APIRouter:
+        """Return FastAPI routes exposing the server's tools."""
+
+        router = APIRouter()
+
+        @router.get("/tools/list")
+        async def list_tools() -> Any:
+            return await self.app.list_tools()
+
+        @router.post("/tool/call")
+        async def call_tool(payload: ToolCall) -> Any:
+            return await self.app.call_tool(payload.name, payload.arguments or {})
+
+        return router

--- a/src/mcp_platform/servers/scaffold_tool.py
+++ b/src/mcp_platform/servers/scaffold_tool.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from mcp.server import FastMCP
+
+from .base import ToolServerBase
+
+
+class ScaffoldToolServer(ToolServerBase):
+    """Minimal tool server used for plugin architecture tests."""
+
+    def __init__(self) -> None:
+        self._app = FastMCP(name="scaffold")
+        self._app.settings.streamable_http_path = "/"
+
+        @self._app.tool()
+        def hello_world() -> str:
+            return "scaffold hello"
+
+        @self._app.tool()
+        def echo(message: str) -> str:
+            return message
+
+    @property
+    def app(self) -> FastMCP:
+        return self._app

--- a/tests/integration/test_plugin_architecture.py
+++ b/tests/integration/test_plugin_architecture.py
@@ -1,0 +1,23 @@
+import sys
+import pathlib
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2] / "src"))
+
+from mcp_platform.main import create_app
+
+
+def test_scaffold_tool_discovery_and_call():
+    app = create_app()
+    with TestClient(app) as client:
+        resp = client.get("/scaffold/tools/list")
+        assert resp.status_code == 200
+        tools = [t["name"] for t in resp.json()]
+        assert "hello_world" in tools
+        assert "echo" in tools
+
+        call_resp = client.post(
+            "/scaffold/tool/call",
+            json={"name": "hello_world", "arguments": {}}
+        )
+        assert call_resp.status_code == 200

--- a/tests/unit/test_plugin_architecture_unit.py
+++ b/tests/unit/test_plugin_architecture_unit.py
@@ -1,0 +1,40 @@
+import sys
+import pathlib
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2] / "src"))
+
+from mcp_platform.servers.scaffold_tool import ScaffoldToolServer
+from mcp_platform.servers.base import ToolServerBase
+from mcp_platform.main import create_app
+
+
+def test_scaffold_router_endpoints():
+    server = ScaffoldToolServer()
+    router = server.router()
+    app = TestClient(router).app  # Create FastAPI app from router
+    client = TestClient(app)
+    resp = client.get("/tools/list")
+    names = [t["name"] for t in resp.json()]
+    assert "hello_world" in names and "echo" in names
+    call_resp = client.post("/tool/call", json={"name": "echo", "arguments": {"message": "hi"}})
+    assert call_resp.json()[1]["result"] == "hi"
+
+
+def test_base_class_not_implemented():
+    class Dummy(ToolServerBase):
+        @property
+        def app(self):
+            return super().app
+
+    dummy = Dummy()
+    with pytest.raises(NotImplementedError):
+        dummy.app
+
+
+def test_create_app_discovers_scaffold():
+    app = create_app()
+    client = TestClient(app)
+    resp = client.get("/scaffold/tools/list")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add `ToolServerBase` with FastAPI router
- implement `ScaffoldToolServer` example plugin
- dynamically discover servers in `create_app`
- test plugin discovery and router behavior

## Testing
- `uv run -- pytest --cov=src/mcp_platform --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_6861761d72dc832cad2ccde1fa3df769