### PR TITLE
Increase server.py coverage

### DIFF
--- a/src/mcp_platform/server.py
+++ b/src/mcp_platform/server.py
@@ -221,4 +221,4 @@ async def main():
         worker_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await worker_task
-        await redis.close()
+        await redis.aclose()


### PR DESCRIPTION
## Summary
- add async unit tests to exercise error paths in `server.py`
- stub out server environment in tests to run main()

## Testing
- `uv run pytest --cov=src/mcp_platform --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_6861bf11dc9c832c97fa410dd5165cd0