### PR TITLE
Add read-note tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,25 @@ Add to your `mcp.json`:
 
 ```
 
+## 📝 Note Management
+
+You can retrieve note contents programmatically using `read_note`:
+
+```python
+from mcp_platform import server
+
+server.notes['welcome'] = 'hello world'
+content = server.read_note('welcome')
+```
+
+`read_note` raises `ValueError` if the note does not exist.
+
+The server also exposes a `read-note` tool to fetch a note via the MCP protocol:
+
+```python
+await server.handle_call_tool('read-note', {'name': 'welcome'})
+```
+
 ## 🧪 Testing
 
 This project follows **strict Test-Driven Development** practices:


### PR DESCRIPTION
## Summary
- expose `read-note` as an MCP tool
- support the new tool in `handle_call_tool`
- document `read-note` usage in README
- test listing and calling the new tool

## Testing
- `uv run pytest -q`
- `uv run -- pytest --cov=src/mcp_platform --cov-report=term-missing -q`


------
https://chatgpt.com/codex/tasks/task_e_687bd8278370832caa17c7b57582212e